### PR TITLE
Add possibility to disable long click

### DIFF
--- a/android-pdf-viewer/src/main/java/com/github/barteksc/pdfviewer/DragPinchManager.java
+++ b/android-pdf-viewer/src/main/java/com/github/barteksc/pdfviewer/DragPinchManager.java
@@ -63,6 +63,10 @@ class DragPinchManager implements GestureDetector.OnGestureListener, GestureDete
         enabled = false;
     }
 
+    void disableLongpress(){
+        gestureDetector.setIsLongpressEnabled(false);
+    }
+
     @Override
     public boolean onSingleTapConfirmed(MotionEvent e) {
         boolean onTapHandled = pdfView.callbacks.callOnTap(e);

--- a/android-pdf-viewer/src/main/java/com/github/barteksc/pdfviewer/PDFView.java
+++ b/android-pdf-viewer/src/main/java/com/github/barteksc/pdfviewer/PDFView.java
@@ -1470,6 +1470,11 @@ public class PDFView extends RelativeLayout {
             return this;
         }
 
+        public Configurator disableLongpress() {
+            PDFView.this.dragPinchManager.disableLongpress();
+            return this;
+        }
+
         public void load() {
             if (!hasSize) {
                 waitingDocumentConfigurator = this;


### PR DESCRIPTION
If user performs a tap and keeps a finger motionless and after start dragging scrolling doesn't perform. In case we don't have any long tap logic the good solution is to set to gestureDetector setIsLongpressEnabled(false) so user can scroll after long tap without any problem.  
Now You can set it using Configurator:  .disableLongpress()